### PR TITLE
Compute polygon opacity depending on zoom level

### DIFF
--- a/src/primary/tree/map/style/createRankPolygonStyleFunction.ts
+++ b/src/primary/tree/map/style/createRankPolygonStyleFunction.ts
@@ -2,11 +2,11 @@ import type { FeatureLike } from 'ol/Feature';
 import { Fill, Style } from 'ol/style';
 import type { View } from 'ol';
 
-const ARCHAE_FILL_COLOR = 'rgba(170, 255, 238, 0.12)';
-const EUKARYOTES_FILL_COLOR = 'rgba(101, 153, 255, 0.15)';
-const BACTERIA_FILL_COLOR = 'rgba(255, 128, 128, 0.1)';
+const ARCHAE_FILL_COLOR = [170, 255, 238, 0.2];
+const EUKARYOTES_FILL_COLOR = [101, 153, 255, 0.23];
+const BACTERIA_FILL_COLOR = [255, 128, 128, 0.18];
 
-const FILL_COLORS: Record<number, string> = {
+const FILL_COLORS: Record<number, Array<number>> = {
   1: ARCHAE_FILL_COLOR,
   2: EUKARYOTES_FILL_COLOR,
   3: BACTERIA_FILL_COLOR,
@@ -14,7 +14,11 @@ const FILL_COLORS: Record<number, string> = {
 
 export function createRankPolygonStyleFunction(view: View): (feature: FeatureLike, resolution: number, context: any) => Style {
   return function (feature: FeatureLike): Style {
-    const fillColor = FILL_COLORS[feature.get('ref') as number];
+    const themeColor = FILL_COLORS[feature.get('ref') as number];
+    const currentZoom = view.getZoom();
+    const zoomLevel = feature.get('zoomview');
+    const opacityFactor = currentZoom !== undefined ? 1 - Math.abs(zoomLevel - currentZoom) / 6 : 1;
+    const fillColor = [themeColor[0], themeColor[1], themeColor[2], themeColor[3] * opacityFactor];
     return new Style({
       fill: new Fill({ color: fillColor }),
       zIndex: 1,


### PR DESCRIPTION
The goal of this PR is to make polygons opacity vary with the zoom level, to make a bit smoother visual transition during zoom, and maybe limit issues with visual inconsistencies. 