### PR TITLE
Only run extended wikidata query if first one fails

### DIFF
--- a/src/secondary/taxon/wikidata-query/WikidataQuery.ts
+++ b/src/secondary/taxon/wikidata-query/WikidataQuery.ts
@@ -14,9 +14,9 @@ export function queryTaxonWikidataRecord(ncbiId: number) {
 }
 
 export function queryTaxonWikipediaPages(ncbiId: number) {
-  return `SELECT DISTINCT ?article ?lang ?name WHERE {
+  return `SELECT DISTINCT ?article ?lang ?name  WHERE {
   {
-    SELECT DISTINCT ?article ?lang ?name WHERE {
+    SELECT DISTINCT ?article ?lang ?name  WHERE {
       ?taxid ps:P685 "${ncbiId}". 
       ?speciesId p:P685 ?taxid.
       ?article schema:about ?speciesId.
@@ -26,17 +26,33 @@ export function queryTaxonWikipediaPages(ncbiId: number) {
       SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]" }
     }
   }
-  UNION {
-    SELECT DISTINCT ?article ?lang ?name WHERE {
-      ?taxid ps:P685 "${ncbiId}". 
-      ?speciesId p:P685 ?taxid.
-      ?species ^wdt:P366 ?speciesId .
-      ?article schema:about ?species.
-      ?article schema:name ?name.
-      ?article schema:isPartOf [ wikibase:wikiGroup "wikipedia" ] . 
-      ?article schema:inLanguage ?lang .
-      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]" }
+  OPTIONAL {
+    {
+      SELECT (COUNT(*) AS ?count) WHERE {
+          SELECT DISTINCT ?article ?lang ?name  WHERE {
+              ?taxid ps:P685 "${ncbiId}". 
+              ?speciesId p:P685 ?taxid.
+              ?article schema:about ?speciesId.
+              ?article schema:name ?name.
+              ?article schema:isPartOf [ wikibase:wikiGroup "wikipedia" ] . 
+              ?article schema:inLanguage ?lang .
+              SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]" }
+          }
+        }
       }
-    }
+      FILTER(?count = 0)
+      {
+        SELECT DISTINCT ?article ?lang ?name  WHERE {
+            ?taxid ps:P685 "${ncbiId}". 
+            ?speciesId p:P685 ?taxid.
+            ?species ^wdt:P366 ?speciesId .
+            ?article schema:about ?species.
+            ?article schema:name ?name.
+            ?article schema:isPartOf [ wikibase:wikiGroup "wikipedia" ] . 
+            ?article schema:inLanguage ?lang .
+            SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]" }
+        }
+      }
+    } 
   }`;
 }


### PR DESCRIPTION
The wikidata query to get wikipedia pages is an union between direct pages corresponding to the ncbi id and pages inheriting from this id.

This PR modifies the query so that the "inerhited" query is only run if the "direct" doesn't yield any result.