### PR TITLE
Health timeout

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -41,6 +41,7 @@
   "sequenced-genomes-label": "Number of genomes fully sequenced",
   "error": "Error",
   "lifemap-not-available-message": "Sorry Lifemap is not available for the moment. Please try again later",
+  "lifemap-availability-check": "Checking if Lifemap is available...",
   "taxon-retrieval-error-message": "An error occurred while retrieving taxa data",
   "taxon-suggestions-error-message": "An error occurred while fetching taxon suggestions",
   "ancestor-error-message": "An error occurred while retrieving taxa ancestries",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -41,6 +41,7 @@
   "sequenced-genomes-label": "Nombre de génomes entièrement séquencés",
   "error": "Erreur",
   "lifemap-not-available-message": "Désolé, Lifemap n'est pas disponible pour le moment. Veuillez réessayer plus tard.",
+  "lifemap-availability-check": "Connexion à Lifemap...",
   "taxon-retrieval-error-message": "Une erreur est survenue lors de la récupération des données du taxon.",
   "taxon-suggestions-error-message": "Une erreur est survenue lors de la récupération des suggestions de taxons.",
   "ancestor-error-message": "Une erreur est survenue lors de la récupération des taxons ancestraux.",

--- a/src/primary/homepage/Homepage.vue
+++ b/src/primary/homepage/Homepage.vue
@@ -38,6 +38,9 @@
             </template>
           </div>
           <div>
+            <template v-if="state === 'PENDING'">
+              <p class="text">{{ $t('lifemap-availability-check') }}</p>
+            </template>
             <template v-if="state === 'SUCCESS'">
               <button class="button -extra-large -main" @click.stop.prevent="goToTree">{{ $t('start-exploring') }}</button>
             </template>

--- a/src/primary/homepage/Homepage.vue
+++ b/src/primary/homepage/Homepage.vue
@@ -39,7 +39,7 @@
           </div>
           <div>
             <template v-if="state === 'PENDING'">
-              <p class="text">{{ $t('lifemap-availability-check') }}</p>
+              <p>{{ $t('lifemap-availability-check') }}</p>
             </template>
             <template v-if="state === 'SUCCESS'">
               <button class="button -extra-large -main" @click.stop.prevent="goToTree">{{ $t('start-exploring') }}</button>

--- a/src/secondary/tree/RESTTreeRepository.ts
+++ b/src/secondary/tree/RESTTreeRepository.ts
@@ -4,6 +4,8 @@ import type { TreeSummary } from '@/domain/tree/TreeSummary';
 import { type RESTTreeSummary, toTreeSummary } from '@/secondary/tree/RESTTreeSummary';
 import { NotFound } from '@/domain/NotFound';
 
+const TIMEOUT = 3000;
+
 export class RESTTreeRepository implements TreeRepository {
   constructor(private axiosInstance: AxiosInstance) {}
 
@@ -20,7 +22,7 @@ export class RESTTreeRepository implements TreeRepository {
   async findIfTreeIsDisplayable(): Promise<boolean> {
     const url = '/vector_tiles/health';
     return this.axiosInstance
-      .get<string>(url)
+      .get<string>(url, { timeout: TIMEOUT })
       .then(response => response.data === 'OK')
       .catch(() => {
         throw new NotFound(`resource at ${url} not found`);
@@ -30,7 +32,7 @@ export class RESTTreeRepository implements TreeRepository {
   async findIfTreeIsAvailable(): Promise<boolean> {
     const url = '/health';
     return this.axiosInstance
-      .get<string>(url)
+      .get<string>(url, { timeout: TIMEOUT })
       .then(response => response.data === 'OK')
       .catch(() => {
         throw new NotFound(`resource at ${url} not found`);


### PR DESCRIPTION
Timeout for displaying error messages whenc checking for backend health when the backend server is unavailable can be very long.

This PR adds a 3 seconds timeout duration, and displays a short message on the message while the health check is performed.